### PR TITLE
Add padding to bottom of SharedLayout

### DIFF
--- a/components/SharedLayout.js
+++ b/components/SharedLayout.js
@@ -7,7 +7,7 @@ export default function SharedLayout({ children }) {
     return (
         <div className='shared-layout'>
             <Navbar />
-            <div className='container'>
+            <div className='container pb-5'>
                 { children }
             </div>
             <Footer />


### PR DESCRIPTION
There's currently not enough space between the main content and the footer, so I added some padding.

<img width="1440" alt="Screen Shot 2021-02-17 at 10 24 05 PM" src="https://user-images.githubusercontent.com/9601737/108300726-dc390e00-716e-11eb-9a84-2877dae8d8c6.png">
