### PR TITLE
CircleCI: fix heroku_deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,6 @@ workflows:
   heroku_deploy:
     jobs:
       - heroku/deploy-via-git:
-        filters:
-          branches:
-            only: staging
+          filters:
+            branches:
+              only: staging


### PR DESCRIPTION
The old config translates into the following JSON:
```
{
    "version": 2.1,
    "orbs": {
        "heroku": "circleci/heroku@1"
    },
    "workflows": {
        "heroku_deploy": {
            "jobs": [
                {
                    "heroku/deploy-via-git": null,
                    "filters": {
                        "branches": {
                            "only": "staging"
                        }
                    }
                }
            ]
        }
    }
}
```
As a result, the deploy-via-git job runs without the filter.

The new config translates into the following JSON:
```
{
    "version": 2.1,
    "orbs": {
        "heroku": "circleci/heroku@1"
    },
    "workflows": {
        "heroku_deploy": {
            "jobs": [
                {
                    "heroku/deploy-via-git": {
                        "filters": {
                            "branches": {
                                "only": "staging"
                            }
                        }
                    }
                }
            ]
        }
    }
}
```