### PR TITLE
Add take action links to state page (#92)

### DIFF
--- a/components/StatesList.js
+++ b/components/StatesList.js
@@ -24,18 +24,22 @@ class StatesList extends Component {
                 <input
                     placeholder="Search for a state..."
                     onChange={this._onChangeSearch}
-                    style={{height: '60px', width: '100%', paddingLeft: 7}}
+                    className="p-2"
+                    style={{height: '60px', width: '100%'}}
                     value={search}
                 />
                 <div className='mt-1' style={{height: '500px', overflowY: 'scroll'}}>
                     {visibleStates.length > 0
-                        ? <ul style={{border: '1px solid #DDDDDD', backgroundColor: 'white', padding: 7}}>
-                            {visibleStates.map(state => (
+                        ? <ul style={{border: '1px solid #DDDDDD', backgroundColor: 'white', padding: 0}}>
+                            {visibleStates.map((state, index) => (
                                 <>
                                     <StateCard
                                         score={state.score}
                                         state={state.state} />
-                                    <hr style={{margin: 0, width: '95%'}}/>
+                                    {/* Do not render hr after last card. */}
+                                    {index !== visibleStates.length - 1 &&
+                                        <hr style={{margin: '0 auto', width: '95%'}}/>
+                                    }
                                 </>
                             ))}
                         </ul>

--- a/components/common/TakeAction.js
+++ b/components/common/TakeAction.js
@@ -1,29 +1,38 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { useRouter } from 'next/router'
 
 import styles from './Common.module.css';
 
+const links = [
+    {path: "/contact-your-legislators", label: "Contact Your Legislators"},
+    {path: "/survivor-power", label: "Build Collective Survivor Power"},
+    {path: "/partner-with-freefrom", label: "Partner with Freefrom"},
+    {path: "/policy-ideas", label: "Share Your Policy Ideas"}
+]
+
+const arrow = <FontAwesomeIcon icon={ faArrowRight } className="mr-1" />
+
 export default function TakeAction() {
+    const { pathname } = useRouter()
     return (
         <div className={ `take-action mt-2 mb-5` }>
             <h1>Take action</h1>
             <div className="d-flex flex-column justify-content-start">
-                <div className="ml-4 my-4">
-                    <a href="/contact-your-legislators" className={`${styles["take-action-link"]}`}>
-                        <FontAwesomeIcon icon={ faArrowRight } className="mr-1" /> Contact Your Legislators
-                    </a>
-                </div>
-                <div className="ml-4 my-4">
-                    <a href="/survivor-power" className={` ${styles["take-action-link"]}`}>
-                        <FontAwesomeIcon icon={ faArrowRight } className="mr-1" /> Build Collective Survivor Power
-                    </a>
-                </div>
-                <div className="ml-4 my-4">
-                    <a href="/policy-ideas" className={` ${styles["take-action-link"]}`}>
-                        <FontAwesomeIcon icon={ faArrowRight } className="mr-1" /> Share Your Policy Ideas
-                    </a>
-                </div>
+                {links.map(({path, label}) => {
+                    // Do not render the link if it links to the current page.
+                    // In other words, if we're on the Policy Ideas page, we
+                    // don't want to show that link.
+                    if (path === pathname) return null
+                    return (
+                        <div className="ml-4 my-4" key={path}>
+                            <a href={path} className={`${styles["take-action-link"]}`}>
+                                {arrow}{' '}{label}
+                            </a>
+                        </div>
+                    )
+                })}
             </div>
         </div>
     )

--- a/components/common/TakeAction.js
+++ b/components/common/TakeAction.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import styles from './Common.module.css';
 
 const links = [
-    {path: "/contact-your-legislators", label: "Contact Your Legislators"},
+    {path: "/contact-legislators", label: "Contact Your Legislators"},
     {path: "/survivor-power", label: "Build Collective Survivor Power"},
     {path: "/partner-with-freefrom", label: "Partner with Freefrom"},
     {path: "/policy-ideas", label: "Share Your Policy Ideas"}

--- a/components/modal/ModalButton.js
+++ b/components/modal/ModalButton.js
@@ -10,13 +10,13 @@ import styles from './Modal.module.css';
 export default function ModalButton({ href, target, text }) {
     if (href) {
         return (
-            <a type="button" className={`btn btn-primary ${styles.button}`} href={href}>
+            <a type="button" className={`btn btn-primary modal-button ${styles.button}`} href={href}>
                 <FontAwesomeIcon icon={ faArrowRight } className="mr-1" /> { text }
             </a>
         )
     }
     return (
-        <button type="button" className={`btn btn-primary ${styles.button}`} data-toggle="modal" data-target={ `#${target}` }>
+        <button type="button" className={`btn btn-primary modal-button ${styles.button}`} data-toggle="modal" data-target={ `#${target}` }>
             <FontAwesomeIcon icon={ faArrowRight } className="mr-1" /> { text }
         </button>
     )

--- a/pages/[state].js
+++ b/pages/[state].js
@@ -5,11 +5,12 @@ import { regenCycle } from 'constants'
 
 import SharedLayout from "components/SharedLayout";
 import Breadcrumbs from "components/common/Breadcrumbs";
+import styles from 'components/common/Common.module.css';
 import ReportMissingInfo from 'components/common/ReportMissingInfo'
-import ScoreLabel from 'components/common/ScoreLabel'
 import ScoringGuide from 'components/common/ScoringGuide'
 import ShareButtons from 'components/common/ShareButtons'
 import StateUpdates from 'components/common/StateUpdates'
+import TakeAction from 'components/common/TakeAction'
 import Glossary from 'components/common/Glossary';
 import ModalButton from "components/modal/ModalButton";
 import Scorecard from 'components/Scorecard';
@@ -38,26 +39,31 @@ export default function State() {
     ]
     return (
         <SharedLayout>
-            <Breadcrumbs currentPageTitle={ state } />
-            <h1>{ stateCapitalized } Survivor Wealth Policy Report</h1>
-            <p>How does { stateCapitalized } measure up to supporting survivor wealth?</p>
-            <div className="row">
-                <div className="col-12 col-md-4">
-                    <img className="img-fluid" src={imageUrl} />
-                    <StateUpdates />
-                    <ReportMissingInfo />
-                    <ShareButtons className="mb-5" />
-                </div>
-                <div className="col-12 col-md-7">
-                    <div className="float-right">
-                        {/* FIXME: add url to report */}
-                        <ModalButton href="#" text="Download report" />
+            <div className='state-page'>
+                <Breadcrumbs currentPageTitle={ state } />
+                <h1>{ stateCapitalized } Survivor Wealth Policy Report</h1>
+                <p>How does { stateCapitalized } measure up to supporting survivor wealth?</p>
+                <div className="row">
+                    <div className="col-12 col-md-4">
+                        <img className="img-fluid" src={imageUrl} />
+                        <StateUpdates />
+                        <ReportMissingInfo />
+                        <ShareButtons className="mb-5" />
                     </div>
-                    <Scorecard categories={categories} overallScore={2} />
-                    <h2>Understanding this report</h2>
-                    <ScoringGuide />
-                    <Glossary />
-                    <h2>Take action</h2>
+                    <div className="col-12 col-md-7">
+                        <div className="float-right">
+                            {/* FIXME: add url to report */}
+                            <ModalButton href="#" text="Download report" />
+                        </div>
+                        <Scorecard categories={categories} overallScore={2} />
+                        <div className="understanding-report">
+                            <h2 className="mb-0" >Understanding this report</h2>
+                            <ScoringGuide />
+                            <Glossary />
+                            <ModalButton href="/methodology" text="Full methodology" />
+                        </div>
+                        <TakeAction />
+                    </div>
                 </div>
             </div>
         </SharedLayout>

--- a/pages/[state].js
+++ b/pages/[state].js
@@ -62,7 +62,7 @@ export default function State() {
                             <Glossary />
                             <ModalButton href="/methodology" text="Full methodology" />
                         </div>
-                        <TakeAction />
+                        <TakeAction showPartnerLink />
                     </div>
                 </div>
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -209,6 +209,7 @@ h4 {
     margin-bottom: 0px;
 }
 
+/* FIXME: Consolidate state page modal button css with take action css */
 .state-page .understanding-report .modal-button {
     font-family: 'Roboto';
     font-weight: 700;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -195,6 +195,40 @@ h4 {
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
+.state-page .take-action > h1 {
+    font-size: 34px;
+}
+
+.state-page .take-action > h1 {
+    font-size: 34px;
+    margin-bottom: 0px;
+}
+
+.state-page .understanding-report button {
+    font-size: 34px;
+    margin-bottom: 0px;
+}
+
+.state-page .understanding-report .modal-button {
+    font-family: 'Roboto';
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 24px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #32B4B4 !important;
+    margin: 27px;
+    padding: 0px;
+}
+
+.state-page .understanding-report .modal-button:hover {
+    color: #32B4B4 !important;
+}
+
+.state-page .understanding-report .modal-button:active {
+    color: #32B4B4 !important;
+}
+
 .scorecard-container > .overall {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This PR closes #92:
- styles the Understanding Report links to match the mocks and
- adds the Take Action links

![image](https://user-images.githubusercontent.com/2370911/108643850-58d33180-747a-11eb-8fe4-de5f189040a3.png)
