### PR TITLE
Fix prop types errors

### DIFF
--- a/components/SharedLayout.js
+++ b/components/SharedLayout.js
@@ -16,5 +16,5 @@ export default function SharedLayout({ children }) {
 }
 
 SharedLayout.propTypes = {
-    children: PropTypes.array
+    children: PropTypes.node
 }

--- a/components/forms/Checkbox.js
+++ b/components/forms/Checkbox.js
@@ -15,7 +15,7 @@ export default function Checkbox({ className, name, children, value }) {
 
 Checkbox.propTypes = {
     className: PropTypes.string,
-    children: PropTypes.string,
+    children: PropTypes.node,
     name: PropTypes.string,
     value: PropTypes.string
 }

--- a/components/modal/Modal.js
+++ b/components/modal/Modal.js
@@ -31,5 +31,6 @@ Modal.propTypes = {
     target: PropTypes.string,
     text: PropTypes.string,
     title: PropTypes.string,
-    children: PropTypes.object
+    children: PropTypes.node,
+    className: PropTypes.string
 }


### PR DESCRIPTION
>```
>// Anything that can be rendered: numbers, strings, elements or an array
>// (or fragment) containing these types.
>// see https://reactjs.org/docs/rendering-elements.html for more info
>optionalNode: PropTypes.node,
>```
>https://github.com/facebook/prop-types

Fix this server error on http://localhost:3000/states/alabama:
```
Warning: Failed prop type: Invalid prop `children` of type `object` supplied to `SharedLayout`, expected `array`.
    in SharedLayout (at [state].js:23)
    in State (at _app.js:16)
    in MyApp
    in Unknown
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in AppContainer
```