### PR TITLE
Configure CircleCI deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,14 @@ workflows:
   heroku_deploy:
     jobs:
       - heroku/deploy-via-git:
+          environment:
+            HEROKU_APP_NAME: freefrom-map-frontend
           filters:
             branches:
               only: staging
+      - heroku/deploy-via-git:
+          environment:
+            HEROKU_APP_NAME: freefrom-map-frontend-prod
+          filters:
+            branches:
+              only: prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,16 @@ workflows:
   heroku_deploy:
     jobs:
       - heroku/deploy-via-git:
-          environment:
-            HEROKU_APP_NAME: freefrom-map-frontend
+          pre-steps:
+            - run:
+              command: HEROKU_APP_NAME=freefrom-map-frontend
           filters:
             branches:
               only: staging
       - heroku/deploy-via-git:
-          environment:
-            HEROKU_APP_NAME: freefrom-map-frontend-prod
+          pre-steps:
+            - run:
+              command: HEROKU_APP_NAME=freefrom-map-frontend-prod
           filters:
             branches:
               only: prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,12 @@ workflows:
   heroku_deploy:
     jobs:
       - heroku/deploy-via-git:
-          pre-steps:
-            - run:
-              command: HEROKU_APP_NAME=freefrom-map-frontend
+          app-name: freefrom-map-frontend
           filters:
             branches:
               only: staging
       - heroku/deploy-via-git:
-          pre-steps:
-            - run:
-              command: HEROKU_APP_NAME=freefrom-map-frontend-prod
+          app-name: freefrom-map-frontend-prod
           filters:
             branches:
               only: prod


### PR DESCRIPTION
- Make CircleCI deploy the `staging` branch to https://freefrom-map-frontend.herokuapp.com/
- Make CircleCI deploy the `prod` branch to https://freefrom-map-frontend-prod.herokuapp.com/ (Heroku doesn't allow `freefrom-map-frontend-production` due to length)

- [ ] We should rename `freefrom-map-frontend` to `freefrom-map-frontend-staging` at some point, but that will change the URL from https://freefrom-map-frontend.herokuapp.com/ to https://freefrom-map-frontend-staging.herokuapp.com/, so we should notify FreeFrom first
- [x] We should delete `HEROKU_APP_NAME` from https://app.circleci.com/settings/project/github/RagtagOpen/freefrom-map-frontend/environment-variables after merging this PR
- [x] We should create a `prod` branch after merging this PR