### PR TITLE
Override default Safari button styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,6 +13,10 @@ body {
   overflow-x: hidden;
 }
 
+[type="button"] {
+  -webkit-appearance: none;
+}
+
 #__next {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Closes #172.
Closes #208.

This PR fixes the mobile display issues we're currently having, which are caused by Safari deciding to style buttons however it wants 😆 The only change I made here was turning off the default button styles. Tagging @DanielKim1 to ask if this is legit from an accessibility standpoint.

![http10 0 1 153000statesalabama](https://user-images.githubusercontent.com/9601737/113997667-5bb99400-9826-11eb-9224-fc813916a0b4.jpeg)