### PR TITLE
Add cookies consent page

### DIFF
--- a/components/CookiesConsent.js
+++ b/components/CookiesConsent.js
@@ -1,10 +1,6 @@
 import React from "react";
 import PropTypes from 'prop-types';
-import { setCookies } from 'utils';
-
-function setCookieInStorage(value) {
-  setCookies(value);
-}
+import { setCookiesInLocalStorage } from 'utils';
 
 function CookiesConsent({ setCookie }) {
   return (
@@ -33,7 +29,7 @@ function CookiesConsent({ setCookie }) {
             className="mr-3 btn btn-secondary"
             onClick={() => {
               setCookie(false);
-              setCookieInStorage(false);
+              setCookiesInLocalStorage(false);
             }}
           >
             Decline
@@ -43,7 +39,7 @@ function CookiesConsent({ setCookie }) {
             className="btn btn-primary"
             onClick={() => {
               setCookie(true);
-              setCookieInStorage(true);
+              setCookiesInLocalStorage(true);
             }}
           >
             Accept

--- a/components/CookiesConsent.js
+++ b/components/CookiesConsent.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from 'prop-types';
+import { setCookies } from 'utils';
+
+function setCookieInStorage(value) {
+  setCookies(value);
+}
+
+function CookiesConsent({ setCookie }) {
+  return (
+    <div className="fixed-top d-flex flex-column w-100 h-100 z-index-2">
+      <div
+        className="flex-fill bg-dark opacity-5"
+        style={{ opacity: 0.5 }}
+      ></div>
+      <div
+        className="bg-dark align-items-center p-5 d-flex flex-column"
+        style={{ minWidth: "200px" }}
+      >
+        <p className="text-white text-center">
+          This website uses cookies to ensure you get the best experience.{" "}
+          <a
+            href="https://www.cookiesandyou.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more.
+          </a>
+        </p>
+        <div className="d-flex flex-row justify-content-center w-100">
+          <button
+            type="button"
+            className="mr-3 btn btn-secondary"
+            onClick={() => {
+              setCookie(false);
+              setCookieInStorage(false);
+            }}
+          >
+            Decline
+          </button>
+
+          <button
+            className="btn btn-primary"
+            onClick={() => {
+              setCookie(true);
+              setCookieInStorage(true);
+            }}
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+CookiesConsent.propTypes = {
+    setCookie: PropTypes.func,
+}
+
+export default CookiesConsent;

--- a/components/SharedLayout.js
+++ b/components/SharedLayout.js
@@ -1,9 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types"
 import Navbar from "./Navbar";
 import Footer from "./Footer";
+import CookiesConsent from 'components/CookiesConsent'
+import { getCookiesFromLocalStorage } from 'utils'
 
 export default function SharedLayout({ children }) {
+    const [cookie, setCookie] = useState(getCookiesFromLocalStorage());
+
     return (
         <div className='shared-layout'>
             <Navbar />
@@ -11,6 +15,7 @@ export default function SharedLayout({ children }) {
                 { children }
             </div>
             <Footer />
+            { cookie != null && cookie != undefined ? null : <CookiesConsent setCookie={setCookie} /> }
         </div>
     );
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "popper.js": "^1.16.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "slugify": "^1.4.7"
+    "slugify": "^1.4.7",
+    "universal-cookie": "^4.0.4"
   },
   "devDependencies": {
     "eslint": "^7.17.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,12 +8,9 @@ import TakeAction from 'components/common/TakeAction'
 import SharedLayout from 'components/SharedLayout'
 import StatesList from 'components/StatesList'
 import UsMap from 'components/UsMap'
-import CookiesConsent from 'components/CookiesConsent'
-import { getCookies } from 'utils'
 
 function Home({ states }) {
     const [visibleComponent, setVisibleComponent] = useState('list');
-    const [cookie, setCookie] = useState(getCookies());
 
     const showList = visibleComponent === 'list'
     const mapClass = showList ? ' d-none d-md-block' : ''
@@ -95,9 +92,7 @@ function Home({ states }) {
                 <img className="img-fluid mb-5" src="/images/snapshot-by-category.png" style={{width: '100%', maxWidth: '1000px'}} />
 
                 <TakeAction />
-
             </>
-            { cookie != null && cookie != undefined ? null : <CookiesConsent setCookie={setCookie} /> }
         </SharedLayout>
     );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 import ReportMissingInfo from 'components/common/ReportMissingInfo'
 import ShareButtons from 'components/common/ShareButtons'
@@ -10,13 +8,17 @@ import TakeAction from 'components/common/TakeAction'
 import SharedLayout from 'components/SharedLayout'
 import StatesList from 'components/StatesList'
 import UsMap from 'components/UsMap'
-import Image from 'next/image'
+import CookiesConsent from 'components/CookiesConsent'
+import { getCookies } from 'utils'
 
 function Home({ states }) {
     const [visibleComponent, setVisibleComponent] = useState('list');
+    const [cookie, setCookie] = useState(getCookies());
+
     const showList = visibleComponent === 'list'
     const mapClass = showList ? ' d-none d-md-block' : ''
     const listClass = showList ? '' : ' d-none d-md-block'
+
     return (
         <SharedLayout>
             <>
@@ -95,6 +97,7 @@ function Home({ states }) {
                 <TakeAction />
 
             </>
+            { cookie != null && cookie != undefined ? null : <CookiesConsent setCookie={setCookie} /> }
         </SharedLayout>
     );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 import ReportMissingInfo from 'components/common/ReportMissingInfo'
 import ShareButtons from 'components/common/ShareButtons'
@@ -8,14 +10,13 @@ import TakeAction from 'components/common/TakeAction'
 import SharedLayout from 'components/SharedLayout'
 import StatesList from 'components/StatesList'
 import UsMap from 'components/UsMap'
+import Image from 'next/image'
 
 function Home({ states }) {
     const [visibleComponent, setVisibleComponent] = useState('list');
-
     const showList = visibleComponent === 'list'
     const mapClass = showList ? ' d-none d-md-block' : ''
     const listClass = showList ? '' : ' d-none d-md-block'
-
     return (
         <SharedLayout>
             <>
@@ -92,6 +93,7 @@ function Home({ states }) {
                 <img className="img-fluid mb-5" src="/images/snapshot-by-category.png" style={{width: '100%', maxWidth: '1000px'}} />
 
                 <TakeAction />
+
             </>
         </SharedLayout>
     );

--- a/utils/cookies.js
+++ b/utils/cookies.js
@@ -3,10 +3,10 @@ import Cookies from "universal-cookie";
 export const COOKIE_KEY = "map-cookie";
 const cookies = new Cookies();
 
-export const setCookies = value => {
+export const setCookiesInLocalStorage = value => {
   cookies.set(COOKIE_KEY, value);
 }
 
-export const getCookies = () => {
-  cookies.get(COOKIE_KEY);
+export const getCookiesFromLocalStorage = () => {
+  return cookies.get(COOKIE_KEY);
 }

--- a/utils/cookies.js
+++ b/utils/cookies.js
@@ -1,0 +1,12 @@
+import Cookies from "universal-cookie";
+
+export const COOKIE_KEY = "map-cookie";
+const cookies = new Cookies();
+
+export const setCookies = value => {
+  cookies.set(COOKIE_KEY, value);
+}
+
+export const getCookies = () => {
+  cookies.get(COOKIE_KEY);
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,5 @@
+import { getCookies, setCookies } from 'utils/cookies';
 import { checkFormStatus, submitForm } from 'utils/forms';
 import { toSlug } from 'utils/routing';
 
-export { checkFormStatus, submitForm, toSlug }
+export { checkFormStatus, submitForm, toSlug, getCookies, setCookies }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
-import { getCookies, setCookies } from 'utils/cookies';
+import { getCookiesFromLocalStorage, setCookiesInLocalStorage } from 'utils/cookies';
 import { checkFormStatus, submitForm } from 'utils/forms';
 import { toSlug } from 'utils/routing';
 
-export { checkFormStatus, submitForm, toSlug, getCookies, setCookies }
+export { checkFormStatus, submitForm, toSlug, getCookiesFromLocalStorage, setCookiesInLocalStorage }

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,6 +151,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -640,6 +645,11 @@ convert-source-map@1.7.0:
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -2767,6 +2777,14 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+universal-cookie@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 unpipe@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes #218 

This PR adds a cookie consent screen when the user first lands on the map. It explains that this site uses cookies and lets the user accept or decline. If they accept, we'll use Google Analytics to track their usage of the site, and if not, Google Analytics will be disabled.

<img width="1440" alt="Screen Shot 2021-04-10 at 10 35 04 AM" src="https://user-images.githubusercontent.com/9601737/114273582-a256ec00-99e8-11eb-870a-9c11ccc48bcd.png">
