### PR TITLE
Reduce tooltip width

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,7 +30,7 @@ body {
 div.tooltip {
   position: absolute;
   padding: 2px;
-  width: 375px;
+  width: min(100vw, 375px);
   font-family: 'Poppins';
   background: #fff;
   border: 0px;


### PR DESCRIPTION
Fix issue on small mobile devices where the document is wider than the viewport, leading to horizontal scroll
Before:
<img width="1552" alt="Screen Shot 2021-04-18 at 2 53 03 PM" src="https://user-images.githubusercontent.com/22206686/115157293-81c90a80-a056-11eb-9e59-bb28cf0d0fdb.png">
After:
<img width="1552" alt="Screen Shot 2021-04-18 at 2 52 21 PM" src="https://user-images.githubusercontent.com/22206686/115157300-855c9180-a056-11eb-9510-929453b55d64.png">