### PR TITLE
Make Acknowledgments and Disclaimer headers smaller on small screens

### DIFF
--- a/pages/acknowledgements.js
+++ b/pages/acknowledgements.js
@@ -7,9 +7,9 @@ export default function Acknowledgements() {
     return (
         <SharedLayout>
             <BackButton className="mt-3 mb-2" />
-            <h1 className="subpage-header">Acknowledgements</h1>
+            <h1 className="ack-header subpage-header">Acknowledgements</h1>
             <p>We want to take a moment to acknowledge that the Policy Map and Scorecard could not have been made possible without the support and contributions made by the law firms, research volunteers and all those involved in this project! We thank you for all of your work and contribution to making this tool a success!</p>
-            <h2>Pro Bono Partners</h2>
+            <h2 className="ack-subheader">Pro Bono Partners</h2>
             <ul className="no-bullets no-indents">
                 <li>Alston & Bird, LLP</li>
                 <li>DLA Piper, LLP</li>
@@ -20,7 +20,7 @@ export default function Acknowledgements() {
                 <li>Seyfarth Shaw, LLP</li>
                 <li>Womble Bond Dickinson (US) LLP</li>
             </ul>
-            <h2>Legal Research Volunteers</h2>
+            <h2 className="ack-subheader">Legal Research Volunteers</h2>
             <ul className="no-bullets no-indents">
                 <li>Dr. Monica Beard</li>
                 <li>Tracy L. Boak, Perlman & Perlman, LLP</li>
@@ -35,15 +35,15 @@ export default function Acknowledgements() {
                 <li>Brooke Thacher</li>
                 <li>Monica Towarnicky</li>
             </ul>
-            <h2>Consultant</h2>
+            <h2 className="ack-subheader">Consultant</h2>
             <ul className="no-bullets no-indents">
                 <li>Priyamvada Kumar</li>
             </ul>
-            <h2>Design</h2>
+            <h2 className="ack-subheader">Design</h2>
             <ul className="no-bullets no-indents">
                 <li>Tiffany Hernandez</li>
             </ul>
-            <h2>Ragtag.org Tech Volunteers</h2>
+            <h2 className="ack-subheader">Ragtag.org Tech Volunteers</h2>
             <ul className="no-bullets no-indents">
                 <li>Jenn Czeck</li>
                 <li>Emily Giurleo</li>
@@ -55,13 +55,13 @@ export default function Acknowledgements() {
                 <li>Grant Stromgren</li>
                 <li>Thaydryan Sweeney</li>
             </ul>
-            <h2>FreeFrom Project Leads</h2>
+            <h2 className="ack-subheader">FreeFrom Project Leads</h2>
             <ul className="no-bullets no-indents">
                 <li>Sabrina Hamm, Policy and Advocacy Specialist</li>
                 <li>Amy Durrence, Director of Systems Change Initiatives</li>
                 <li>Sonya Passi, CEO & Founder</li>
             </ul>
-            <h2>FreeFrom Outreach and Dissemination Team</h2>
+            <h2 className="ack-subheader">FreeFrom Outreach and Dissemination Team</h2>
             <ul className="no-bullets no-indents">
                 <li>Anakaren Alcocer</li>
                 <li>Diana Ayala</li>

--- a/pages/disclaimer.js
+++ b/pages/disclaimer.js
@@ -6,7 +6,7 @@ export default function Disclaimer() {
     return (
         <SharedLayout>
             <BackButton className="mt-3 mb-2" />
-            <h1 className="subpage-header">Disclaimer</h1>
+            <h1 className="disclaimer-header subpage-header">Disclaimer</h1>
             <p>This is an educational and informational tool and the information contained within it does in no way constitute legal advice. Any person who intends to use the information contained herein in any way is solely responsible for independently verifying the information and obtaining independent legal or other expert advice if necessary.</p>
         </SharedLayout>
     )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -454,13 +454,21 @@ input {
 }
 
 @media screen and (max-width: 440px) {
-  .methodology-header {
+  .methodology-header, .disclaimer-header {
     font-size: 34px;
     line-height: 34px;
   }
   .methodology-subheader {
     font-size: 26px;
     line-height: 26px;
+  }
+  .ack-header {
+    font-size: 24px;
+    line-height: 24px;
+  }
+  .ack-subheader {
+    font-size: 18px;
+    line-height: 18px;
   }
   .big-indents, .no-bullets {
     padding-left: 30px;


### PR DESCRIPTION
These are currently getting cut off on small screens (320px). The other headers throughout the site look nice as-is on small screens, so I'm just targeting the ones that aren't working.

Very open to feedback if there's a better way to approach this!

Closes #253 