### PR TITLE
Move ReactGA initialize to tracking utility

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,4 @@
 import { useEffect } from "react"
-import { getCookiesFromLocalStorage } from 'utils';
 
 // CSS
 import 'bootstrap/dist/css/bootstrap.min.css'
@@ -12,10 +11,6 @@ export default function MyApp({ Component, pageProps }) {
             window.$ = window.jQuery = $;
             return import("bootstrap");
         });
-
-        if(getCookiesFromLocalStorage && process.env.NEXT_PUBLIC_GA_ID) {
-            ReactGA.initialize(process.env.NEXT_PUBLIC_GA_ID);
-        }
     }, []);
 
     return <Component {...pageProps} />

--- a/utils/tracking.js
+++ b/utils/tracking.js
@@ -1,6 +1,10 @@
 import ReactGA from "react-ga"
 import { getCookiesFromLocalStorage } from 'utils';
 
+if(process.env.NEXT_PUBLIC_GA_ID) {
+    ReactGA.initialize(process.env.NEXT_PUBLIC_GA_ID);
+}
+
 export const trackPageView = (url) => {
     if(getCookiesFromLocalStorage && process.env.NEXT_PUBLIC_GA_ID) {
         ReactGA.pageview(url);


### PR DESCRIPTION
I accidentally broke Google Analytics by moving the initializer to the wrong place. This should fix it!