### PR TITLE
Force app to redirect http to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "node server.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
@@ -15,6 +15,7 @@
     "bootstrap": "^4.5.3",
     "d3": "3",
     "formik": "^2.2.6",
+    "heroku-ssl-redirect": "^0.1.1",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",
     "next": "^10.0.7",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const next = require('next');
+const express = require('express');
+const sslRedirect = require('heroku-ssl-redirect');
+
+const port = parseInt(process.env.PORT, 10) || 3000;
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+    const server = express();
+
+    // redirect to SSL
+    server.use(sslRedirect());
+
+    server.all('*', (req, res) => {
+        return handle(req, res);
+    });
+
+    server.listen(port, err => {
+        if (err) throw err;
+        console.log(`> Ready on http://localhost:${port}`);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,6 +1355,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+heroku-ssl-redirect@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/heroku-ssl-redirect/-/heroku-ssl-redirect-0.1.1.tgz#c55d60c0ec4473358ead66c75e8c7e99d9e8a689"
+  integrity sha512-kL/DvLR2J53iB3TXasQlo5JwF/j2L2zkala6Ddk9o6JwIPeDvbTGT9Aty8WElxcF389ObICCeyf2m7RKpCg5Bg==
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
I am trying to solve the problem of Heroku not redirecting by default from http to https. To arrive at this solution, I followed [this blog post](https://medium.com/@tpae/enabling-ssl-https-on-next-js-with-heroku-55d0c6ce8516). I've never tried this before, so not 100% sure it'll work, but we'll give it a try.